### PR TITLE
Resolved issue with other plugins and org.joda.time dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ work
 .project
 .settings
 .bak
+.idea
+dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,6 @@
             <compatibleSinceVersion>1.4.0</compatibleSinceVersion>
           </configuration>
         </plugin>
-
         <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>animal-sniffer-maven-plugin</artifactId>
@@ -149,7 +148,7 @@
                 <goals>
                   <goal>check</goal>
                 </goals>
-              </execution>
+           </execution>
             </executions>
             <configuration>
               <signature>
@@ -158,6 +157,27 @@
                 <version>1.0</version>
               </signature>
             </configuration>
+        </plugin>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-shade-plugin</artifactId>
+              <version>2.4.2</version>
+              <configuration>
+                  <relocations>
+                      <relocation>
+                          <pattern>org.joda.time</pattern>
+                          <shadedPattern>org.emendashaded.joda.time</shadedPattern>
+                      </relocation>
+                  </relocations>
+              </configuration>
+              <executions>
+                  <execution>
+                      <phase>package</phase>
+                      <goals>
+                          <goal>shade</goal>
+                      </goals>
+                  </execution>
+              </executions>
           </plugin>
       </plugins>
   </build>


### PR DESCRIPTION
Added apache shade plugin and shaded org.joda.time used by kwxsync config step due to incompatibility with other plugins. When other plugins are loaded into Jenkins with different versions of the same dependency specified the plugin's classpath that is loaded first is used. Errors occur when a newer version is compiled with a different version of Java to the older version.