### PR TITLE
Fixed two issues:

### DIFF
--- a/src/main/java/com/emenda/klocwork/util/KlocworkBuildSpecParser.java
+++ b/src/main/java/com/emenda/klocwork/util/KlocworkBuildSpecParser.java
@@ -66,10 +66,13 @@ public class KlocworkBuildSpecParser extends MasterToSlaveCallable<List<String>,
             }
         }
         for (String file : fileList) {
-            // for optimisation we could do String compare, but feels like it is
-            // safer to compare Path(s)
-            if (buildSpecFiles.contains(file)) {
-                validFiles.add(file);
+                //The compare method is case sensitive and on windows should be handled insensitively due to issues were
+                //the diff list returned from the svn has a different case
+                for (String bsFile : buildSpecFiles) {
+                if ((bsFile.contains("\\") && bsFile.toLowerCase().equals(file.toLowerCase()))
+                                || (!bsFile.contains("\\") && bsFile.equals(file))) {
+                    validFiles.add(file);
+                }
             }
         }
         return validFiles;

--- a/src/main/java/com/emenda/klocwork/util/KlocworkUtil.java
+++ b/src/main/java/com/emenda/klocwork/util/KlocworkUtil.java
@@ -153,7 +153,8 @@ public class KlocworkUtil {
         if (launcher.isUnix()) {
             cmds = new ArgumentListBuilder("/bin/sh", "-c", cmds.toString());
         } else {
-            cmds = cmds.toWindowsCommand();
+            cmds.add("&&", "exit", "%%ERRORLEVEL%%");
+            cmds = new ArgumentListBuilder("cmd.exe", "/C", cmds.toString());
         }
         try {
             int returnCode = launcher.launch().
@@ -177,7 +178,8 @@ public class KlocworkUtil {
         if (launcher.isUnix()) {
             cmds = new ArgumentListBuilder("/bin/sh", "-c", cmds.toString());
         } else {
-            cmds = cmds.toWindowsCommand();
+            cmds.add("&&", "exit", "%%ERRORLEVEL%%");
+            cmds = new ArgumentListBuilder("cmd.exe", "/C", cmds.toString());
         }
         try {
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();


### PR DESCRIPTION
#1 For the diff analysis we verify the file is part of the build spec
list, this was case sensitive. On windows we were seeing an issue were
the git diff returned a path with a different case to the file system.
As windows is case in-sensitive anyway, I have changed our comparison
to be case in-sensitive for paths in a windows format.

#2 Also with the diff analysis, the Jenkins toWindowsCommand() call was
incorrectly handling the git diff command to put quotes around the pipe
to a file. e.g. git diff <rev> ">" diff_list.txt. I have changed this to
just use the argument list builder and add the prefix/suffix as we do in
the same style for Linux.