### PR TITLE
Fix gateway report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   </properties>
 
   <artifactId>klocwork</artifactId>
-  <version>2.3.4-SNAPSHOT</version>
+  <version>2.3.4</version>
   <name>Klocwork Community Plug-in</name>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Klocwork+Community+Plugin</url>
   <packaging>hpi</packaging>
@@ -66,7 +66,7 @@
     <connection>scm:git:ssh://github.com:jenkinsci/klocwork-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/klocwork-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/klocwork-plugin.git</url>
-    <tag>HEAD</tag>
+    <tag>klocwork-2.3.4</tag>
   </scm>
 
   <repositories>


### PR DESCRIPTION
Hi Emenda development team,

I installed Klocwork Community Plug-in 2.3.4 from Jenkins plugin manager and created new job for kwciagent, then tried to add the quality gateway to post-build step, but I couldn't add it due to the following exception.

org.apache.commons.jelly.JellyTagException: jar:file:/C:/Program%20Files%20(x86)/Jenkins/war/WEB-INF/lib/jenkins-core-2.121.2.jar!/lib/form/property.jelly:40:72: <st:include> No page found 'config.jelly' for class com.emenda.klocwork.config.KlocworkGatewayCiConfig$DescriptorImpl

This is why I send this pull request. 
My Jenkins version is 2.121.2.

Regards,
Junko Ishii from MSYS, Japan