### PR TITLE
Initial support for Jenkins Configuration as Code (JCasC) plugin

### DIFF
--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -1,0 +1,8 @@
+jenkins:
+  systemMessage: "klocwork"
+
+unclassified:
+  klocworkWrapper:
+    globalLicenseHost: abc.com
+    globalLicensePort: 111
+

--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -5,4 +5,17 @@ unclassified:
   klocworkWrapper:
     globalLicenseHost: abc.com
     globalLicensePort: 111
+    serverConfigs:
+      - name: KW_SERVER_1
+        url: http://klocworkServer2:8080
+        specificLicense: true
+        licenseHost: licenseHost
+        licensePort: 27000
+      - name: KW_SERVER_2
+        url: http://klocworkServer1:8082
+    installConfigs:
+      - name: WindowsBuildSlaves
+        paths: C:\Klocwork\Server\bin;C:\Klocwork\kwciagent\bin
+
+
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.3</version>
+        <version>3.36</version>
     </parent>
 
     <properties>
@@ -11,9 +11,7 @@
         If your are using the Plugin Parent POM version 2.3 or later, just set the jenkins.version property to the version you need to depend on
         Source: https://wiki.jenkins-ci.org/display/JENKINS/Choosing+Jenkins+version+to+build+against
         -->
-        <jenkins.version>1.614</jenkins.version>
-        <hpi-plugin.version>1.115</hpi-plugin.version>
-        <jenkins-test-harness.version>${jenkins.version}</jenkins-test-harness.version>
+        <jenkins.version>2.73</jenkins.version>
         <findbugs.failOnError>false</findbugs.failOnError>
         <java.level>8</java.level>
     </properties>
@@ -214,13 +212,13 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.5</version>
+            <version>3.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>job-dsl</artifactId>
-            <version>1.58</version>
+            <version>1.68</version>
             <optional>true</optional>
         </dependency>
 
@@ -240,7 +238,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.7</version>
+            <version>1.13</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.36</version>
+        <version>2.3</version>
     </parent>
 
     <properties>
@@ -11,7 +11,9 @@
         If your are using the Plugin Parent POM version 2.3 or later, just set the jenkins.version property to the version you need to depend on
         Source: https://wiki.jenkins-ci.org/display/JENKINS/Choosing+Jenkins+version+to+build+against
         -->
-        <jenkins.version>2.73</jenkins.version>
+        <jenkins.version>1.614</jenkins.version>
+        <hpi-plugin.version>1.115</hpi-plugin.version>
+        <jenkins-test-harness.version>${jenkins.version}</jenkins-test-harness.version>
         <findbugs.failOnError>false</findbugs.failOnError>
         <java.level>8</java.level>
     </properties>
@@ -212,13 +214,13 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.7</version>
+            <version>3.5</version>
         </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>job-dsl</artifactId>
-            <version>1.68</version>
+            <version>1.58</version>
             <optional>true</optional>
         </dependency>
 
@@ -238,7 +240,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.13</version>
+            <version>1.7</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/src/main/java/com/emenda/klocwork/KlocworkBuildWrapper.java
+++ b/src/main/java/com/emenda/klocwork/KlocworkBuildWrapper.java
@@ -10,7 +10,6 @@ import hudson.model.AbstractProject;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.BuildWrapperDescriptor;
-import hudson.util.CopyOnWriteList;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.tasks.SimpleBuildWrapper;
@@ -24,6 +23,8 @@ import org.kohsuke.stapler.StaplerRequest;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class KlocworkBuildWrapper extends SimpleBuildWrapper {
 
@@ -134,8 +135,8 @@ public class KlocworkBuildWrapper extends SimpleBuildWrapper {
 
          private String globalLicenseHost;
          private String globalLicensePort;
-         private CopyOnWriteList<KlocworkServerConfig> serverConfigs = new CopyOnWriteList<KlocworkServerConfig>();
-         private CopyOnWriteList<KlocworkInstallConfig> installConfigs = new CopyOnWriteList<KlocworkInstallConfig>();
+         private List<KlocworkServerConfig> serverConfigs = new ArrayList<KlocworkServerConfig>();
+         private List<KlocworkInstallConfig> installConfigs = new ArrayList<KlocworkInstallConfig>();
 
         public DescriptorImpl() {
             load();
@@ -175,7 +176,7 @@ public class KlocworkBuildWrapper extends SimpleBuildWrapper {
         }
 
         @DataBoundSetter
-        public void setServerConfigs(CopyOnWriteList<KlocworkServerConfig> serverConfigs) {
+        public void setServerConfigs(ArrayList<KlocworkServerConfig> serverConfigs) {
             this.serverConfigs = serverConfigs;
         }
 
@@ -184,7 +185,7 @@ public class KlocworkBuildWrapper extends SimpleBuildWrapper {
         }
 
         @DataBoundSetter
-        public void setInstallConfigs(CopyOnWriteList<KlocworkInstallConfig> installConfigs) {
+        public void setInstallConfigs(ArrayList<KlocworkInstallConfig> installConfigs) {
             this.installConfigs = installConfigs;
         }
 

--- a/src/main/java/com/emenda/klocwork/KlocworkBuildWrapper.java
+++ b/src/main/java/com/emenda/klocwork/KlocworkBuildWrapper.java
@@ -18,6 +18,7 @@ import net.sf.json.JSONObject;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -150,23 +151,41 @@ public class KlocworkBuildWrapper extends SimpleBuildWrapper {
 
         @Override
         public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
-            serverConfigs.replaceBy(req.bindJSONToList(KlocworkServerConfig.class, formData.get("serverConfigs")));
-            installConfigs.replaceBy(req.bindJSONToList(KlocworkInstallConfig.class, formData.get("installConfigs")));
-            globalLicenseHost = formData.getString("globalLicenseHost");
-            globalLicensePort = formData.getString("globalLicensePort");
+            req.bindJSON(this, formData);
             save();
             return super.configure(req,formData);
         }
 
         public String getGlobalLicenseHost() { return globalLicenseHost; }
+
+        @DataBoundSetter
+        public void setGlobalLicenseHost(String globalLicenseHost) {
+            this.globalLicenseHost = globalLicenseHost;
+        }
+
         public String getGlobalLicensePort() { return globalLicensePort; }
+
+        @DataBoundSetter
+        public void setGlobalLicensePort(String globalLicensePort) {
+            this.globalLicensePort = globalLicensePort;
+        }
 
         public KlocworkServerConfig[] getServerConfigs() {
             return serverConfigs.toArray(new KlocworkServerConfig[0]);
         }
 
+        @DataBoundSetter
+        public void setServerConfigs(CopyOnWriteList<KlocworkServerConfig> serverConfigs) {
+            this.serverConfigs = serverConfigs;
+        }
+
         public KlocworkInstallConfig[] getInstallConfigs() {
             return installConfigs.toArray(new KlocworkInstallConfig[0]);
+        }
+
+        @DataBoundSetter
+        public void setInstallConfigs(CopyOnWriteList<KlocworkInstallConfig> installConfigs) {
+            this.installConfigs = installConfigs;
         }
 
         public KlocworkServerConfig getServerConfig(String name) {

--- a/src/main/java/com/emenda/klocwork/config/KlocworkInstallConfig.java
+++ b/src/main/java/com/emenda/klocwork/config/KlocworkInstallConfig.java
@@ -1,6 +1,7 @@
 
 package com.emenda.klocwork.config;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import hudson.Extension;
@@ -24,6 +25,7 @@ public class KlocworkInstallConfig extends AbstractDescribableImpl<KlocworkInsta
     public String getName() { return name; }
     public String getPaths() { return paths; }
 
+    @Symbol("installConfigs")
     @Extension
     public static class DescriptorImpl extends Descriptor<KlocworkInstallConfig> {
         public String getDisplayName() { return null; }

--- a/src/main/java/com/emenda/klocwork/config/KlocworkServerConfig.java
+++ b/src/main/java/com/emenda/klocwork/config/KlocworkServerConfig.java
@@ -6,6 +6,7 @@ import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.util.FormValidation;
 import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
@@ -55,7 +56,7 @@ public class KlocworkServerConfig extends AbstractDescribableImpl<KlocworkServer
     public String getLicensePort() {
         return licensePort;
     }
-
+    @Symbol("serverConfigs")
     @Extension
     public static class DescriptorImpl extends Descriptor<KlocworkServerConfig> {
         public String getDisplayName() { return null; }


### PR DESCRIPTION
A minor change to the way Klocwork server and installation configurations are stored exposes them correctly to the JCasC plugin.