### PR TITLE
Klocwork plugin save configuration fix

### DIFF
--- a/src/main/java/com/emenda/klocwork/KlocworkBuildWrapper.java
+++ b/src/main/java/com/emenda/klocwork/KlocworkBuildWrapper.java
@@ -152,6 +152,12 @@ public class KlocworkBuildWrapper extends SimpleBuildWrapper {
 
         @Override
         public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+            serverConfigs.clear();
+            serverConfigs.addAll(req.bindJSONToList(KlocworkServerConfig.class,
+                    formData.get("serverConfigs")));
+            installConfigs.clear();
+            installConfigs.addAll(req.bindJSONToList(KlocworkInstallConfig.class, 
+                    formData.get("installConfigs")));
             req.bindJSON(this, formData);
             save();
             return super.configure(req,formData);


### PR DESCRIPTION
Returned plugin to intended state of saving `List`s installConfigs and serverConfigs using `addAll` instead of previous `replaceBy`. This should provide JCasC compatibility while maintaining normal behaviour external to the JCasC plugin.