### PR TITLE
Japan use

### DIFF
--- a/src/main/java/com/emenda/klocwork/KlocworkGatewayPublisher.java
+++ b/src/main/java/com/emenda/klocwork/KlocworkGatewayPublisher.java
@@ -132,7 +132,7 @@ public class KlocworkGatewayPublisher extends Publisher implements SimpleBuildSt
                             }
                             serverIssues.add(new KlocworkIssue(jObj.getString("id"),
                                     jObj.getString("code"), jObj.getString("message"), jObj.getString("file"),
-                                    line, jObj.getString("severity"), jObj.getString("status")
+                                    line, jObj.getString("severity"), jObj.getString("severityCode"), jObj.getString("status")
                             ));
                         }
                     }

--- a/src/main/java/com/emenda/klocwork/KlocworkServerLoadBuilder.java
+++ b/src/main/java/com/emenda/klocwork/KlocworkServerLoadBuilder.java
@@ -131,12 +131,12 @@ public class KlocworkServerLoadBuilder extends Builder implements SimpleBuildSte
 
         Map<String, Integer> severityMap = new HashMap<String,Integer>();
         for (int i = 0; i < response.size(); i++) {
-            String severity = response.getJSONObject(i).getString("severity");
-            if (StringUtils.isEmpty(severity)) {
+            String severity = response.getJSONObject(i).getString("severityCode");
+            if (StringUtils.isEmpty(severity) || StringUtils.isEmpty(getSeverity_en(severity))) {
                 logger.logMessage(String.format("WARNING: found empty severity %s", severity));
             } else {
                 // increment count
-                severityMap.put(severity, severityMap.getOrDefault(severity, 0) + 1);
+                severityMap.put(getSeverity_en(severity), severityMap.getOrDefault(getSeverity_en(severity), 0) + 1);
             }
         }
 
@@ -170,5 +170,30 @@ public class KlocworkServerLoadBuilder extends Builder implements SimpleBuildSte
             save();
             return super.configure(req,formData);
         }
+    }
+    
+    private String getSeverity_en(String severityCode) {
+    	String severity_en = "";
+    	int severityLevel = 0;
+		try {
+			severityLevel = Integer.parseInt(severityCode);
+		} catch (NumberFormatException e) {
+			e.printStackTrace();
+		}
+    	switch(severityLevel) {
+    	case 1:
+    		severity_en = KlocworkConstants.KLOCWORK_ISSUE_CRITICAL;
+    		break;
+    	case 2:
+    		severity_en = KlocworkConstants.KLOCWORK_ISSUE_ERROR;
+    		break;
+    	case 3:
+    		severity_en = KlocworkConstants.KLOCWORK_ISSUE_WARNING;
+    		break;
+    	case 4:
+    		severity_en = KlocworkConstants.KLOCWORK_ISSUE_REVIEW;
+    		break;
+    	}
+    	return severity_en;
     }
 }

--- a/src/main/java/com/emenda/klocwork/definitions/KlocworkIssue.java
+++ b/src/main/java/com/emenda/klocwork/definitions/KlocworkIssue.java
@@ -9,17 +9,19 @@ public class KlocworkIssue implements Serializable {
     private String file;
     private String line;
     private String severity;
+    private String severitylevel;
     private String status;
 
     public KlocworkIssue() {}
 
-    public KlocworkIssue(String id, String code, String message, String file, String line, String severity, String status) {
+    public KlocworkIssue(String id, String code, String message, String file, String line, String severity, String severitylevel, String status) {
         this.id = id;
         this.code = code;
         this.message = message;
         this.file = file;
         this.line = line;
         this.severity = severity;
+        this.severitylevel = severitylevel;
         this.status = status;
     }
 
@@ -71,7 +73,15 @@ public class KlocworkIssue implements Serializable {
         this.severity = severity;
     }
 
-    public String getStatus() {
+    public String getSeveritylevel() {
+		return severitylevel;
+	}
+
+	public void setSeveritylevel(String severitylevel) {
+		this.severitylevel = severitylevel;
+	}
+
+	public String getStatus() {
         return status;
     }
 

--- a/src/main/java/com/emenda/klocwork/util/KlocworkUtil.java
+++ b/src/main/java/com/emenda/klocwork/util/KlocworkUtil.java
@@ -203,7 +203,11 @@ public class KlocworkUtil {
         int returnCode = 0;
         if(ciTool.equalsIgnoreCase("kwciagent")){
             try {
-                outputStream.writeTo(xmlReport.write());
+            	if (launcher.isUnix()) {
+            		outputStream.writeTo(xmlReport.write());
+            	} else {
+            		xmlReport.write().write(outputStream.toString().replaceFirst("MS932", "UTF-8").getBytes("UTF-8"));
+            	}
             } catch (IOException | InterruptedException e) {
                 returnCode = 1;
                 listener.getLogger().println(e.getMessage());

--- a/src/main/java/com/emenda/klocwork/util/KlocworkXMLReportHandler.java
+++ b/src/main/java/com/emenda/klocwork/util/KlocworkXMLReportHandler.java
@@ -59,12 +59,15 @@ public class KlocworkXMLReportHandler extends DefaultHandler  {
             case "severity":
                 issue.setSeverity(element.toString());
                 break;
+            case "severitylevel":
+            	issue.setSeveritylevel(element.toString());
+            	break;
             case "citingstatus":
                 issue.setStatus(element.toString());
                 break;
             case "problem":
-                if(((issue.getSeverity().toLowerCase().startsWith("severity") && enabledSeverites.getEnabled().get("fiveToTen"))
-                        || enabledSeverites.getEnabled().get(issue.getSeverity().toLowerCase()))
+            	if(((enabledSeverites.getEnabled().get("fiveToTen") && 10 - Integer.parseInt(issue.getSeveritylevel()) < 6 )
+                        || enabledSeverites.getEnabled().get(getSeverity_en(Integer.parseInt(issue.getSeveritylevel()))))
                         && enabledStatuses.getEnabled().get(issue.getStatus().toLowerCase())) {
                     this.totalIssueCount++;
                     if (enableHTMLReport) {
@@ -85,6 +88,33 @@ public class KlocworkXMLReportHandler extends DefaultHandler  {
         if (!text.trim().isEmpty()) {
             element.append(text);
         }
+    }
+    
+    private String getSeverity_en(int severityLevel) {
+    	String severity_en = "";
+    	switch(severityLevel) {
+    	case 1:
+    		severity_en = "critical";
+    		break;
+    	case 2:
+    		severity_en = "error";
+    		break;
+    	case 3:
+    		severity_en = "warning";
+    		break;
+    	case 4:
+    		severity_en = "review";
+    		break;
+    	case 5:
+    	case 6:
+    	case 7:
+    	case 8:
+    	case 9:
+    	case 10:
+    		severity_en = "fiveToTen";
+    		break;
+    	}
+    	return severity_en;
     }
 
     private String currentElement() {


### PR DESCRIPTION
Hi Emenda team,

I fixed the NullPointerException occurence in the KlocworkXMLReportHandler.endElement() process because the severity value is Japanese on Japanese environment. 
Also,fixed that Klocwork Issue Trend chart wasn't the displayed correctly due to the same reason. 
And then, kwcheck_report.xml is generated in UTF-8 when the system encoding is
MS932 now.

Some fixes aren't in a good manner,so please review my changes.

Regards,
Junko 
