### PR TITLE
Update to get the project ID for use in server URL links

### DIFF
--- a/src/main/java/com/emenda/klocwork/KlocworkBuildAction.java
+++ b/src/main/java/com/emenda/klocwork/KlocworkBuildAction.java
@@ -26,6 +26,7 @@ public class KlocworkBuildAction implements Action, SimpleBuildStep.LastBuildAct
     private final String klocworkURL;
     private final String klocworkProject;
     private final KlocworkReportConfig reportConfig;
+    private final String projectId;
 
     public KlocworkBuildAction(Run<?, ?> run, Map<String, Integer> severityMap, EnvVars envVars, String buildName,
             KlocworkReportConfig reportConfig) {
@@ -38,6 +39,21 @@ public class KlocworkBuildAction implements Action, SimpleBuildStep.LastBuildAct
         this.klocworkURL = KlocworkUtil.getNormalizedKlocworkUrl(envVars);
         this.klocworkProject = envVars.get(KlocworkConstants.KLOCWORK_PROJECT);
         this.reportConfig = reportConfig;
+        this.projectId = "";
+    }
+
+    public KlocworkBuildAction(Run<?, ?> run, Map<String, Integer> severityMap, EnvVars envVars, String buildName,
+                               KlocworkReportConfig reportConfig, String projectID) {
+        this.run = run;
+        this.criticalCount = severityMap.getOrDefault(KlocworkConstants.KLOCWORK_ISSUE_CRITICAL, 0);
+        this.errorCount = severityMap.getOrDefault(KlocworkConstants.KLOCWORK_ISSUE_ERROR, 0);
+        this.warningCount = severityMap.getOrDefault(KlocworkConstants.KLOCWORK_ISSUE_WARNING, 0);
+        this.reviewCount = severityMap.getOrDefault(KlocworkConstants.KLOCWORK_ISSUE_REVIEW, 0);
+        this.buildName = KlocworkUtil.getDefaultBuildName(buildName, envVars);
+        this.klocworkURL = KlocworkUtil.getNormalizedKlocworkUrl(envVars);
+        this.klocworkProject = envVars.get(KlocworkConstants.KLOCWORK_PROJECT);
+        this.reportConfig = reportConfig;
+        this.projectId = projectID;
     }
 
     public Run<?, ?> getRun() {
@@ -54,7 +70,12 @@ public class KlocworkBuildAction implements Action, SimpleBuildStep.LastBuildAct
 
     public String getUrlName() {
         try {
-            return KlocworkUtil.getBuildIssueListUrl(klocworkURL, klocworkProject, buildName);
+            if(projectId == null || projectId.equals("")){
+                return KlocworkUtil.getBuildIssueListUrl(klocworkURL, klocworkProject, buildName);
+            }
+            else {
+                return KlocworkUtil.getBuildIssueListUrl(klocworkURL, projectId, buildName);
+            }
         } catch (UnsupportedEncodingException ex) {
             return null;
         }
@@ -98,6 +119,10 @@ public class KlocworkBuildAction implements Action, SimpleBuildStep.LastBuildAct
 
     public String getChartHeight() {
         return reportConfig.getChartHeight();
+    }
+
+    public String getProjectId() {
+        return projectId;
     }
 
     @Override

--- a/src/main/java/com/emenda/klocwork/KlocworkGatewayPublisher.java
+++ b/src/main/java/com/emenda/klocwork/KlocworkGatewayPublisher.java
@@ -5,7 +5,6 @@ import com.emenda.klocwork.config.KlocworkGatewayConfig;
 import com.emenda.klocwork.config.KlocworkGatewayServerConfig;
 import com.emenda.klocwork.reporting.KlocworkDashboard;
 import com.emenda.klocwork.reporting.KlocworkProjectRedirectLink;
-import com.emenda.klocwork.services.KlocworkApiConnection;
 import com.emenda.klocwork.definitions.KlocworkIssue;
 import com.emenda.klocwork.util.KlocworkUtil;
 import com.emenda.klocwork.util.KlocworkXMLReportParser;
@@ -20,7 +19,6 @@ import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import com.emenda.klocwork.util.KlocworkXMLReportParserIssueList;
-import hudson.*;
 import hudson.model.*;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
@@ -29,14 +27,11 @@ import hudson.tasks.Publisher;
 import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
 import java.lang.InterruptedException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -105,7 +100,7 @@ public class KlocworkGatewayPublisher extends Publisher implements SimpleBuildSt
             // check env vars are set, otherwise this throws AbortException
             KlocworkUtil.validateServerConfigs(envVars);
             for (KlocworkGatewayServerConfig pfConfig : gatewayConfig.getGatewayServerConfigs()) {
-                String request = KlocworkUtil.createKlocworkAPIRequest(
+                String request = KlocworkUtil.createKlocworkAPIRequestOld(
                     "search", pfConfig.getQuery(), envVars);
                 logger.logMessage("Condition Name : " + pfConfig.getConditionName());
                 logger.logMessage("Using query: " + request);

--- a/src/main/java/com/emenda/klocwork/KlocworkProjectAction.java
+++ b/src/main/java/com/emenda/klocwork/KlocworkProjectAction.java
@@ -27,7 +27,12 @@ public class KlocworkProjectAction implements Action {
     public String getUrlName() {
         KlocworkBuildAction buildAction = getLatestBuildAction();
         if (buildAction != null) {
-            return KlocworkUtil.getIssueListUrl(buildAction.getKlocworkURL(), buildAction.getKlocworkProject());
+            if(buildAction.getProjectId() == null || buildAction.getProjectId().equals("")){
+                return KlocworkUtil.getIssueListUrl(buildAction.getKlocworkURL(), buildAction.getKlocworkProject());
+            }
+            else{
+                return KlocworkUtil.getIssueListUrl(buildAction.getKlocworkURL(), buildAction.getProjectId());
+            }
         }
         return "";
     }

--- a/src/main/java/com/emenda/klocwork/util/KlocworkUtil.java
+++ b/src/main/java/com/emenda/klocwork/util/KlocworkUtil.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.net.URLEncoder;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -388,8 +389,8 @@ public class KlocworkUtil {
         return returnCode;
     }
 
-    public static String createKlocworkAPIRequest(String action,
-        String query, EnvVars envVars) throws AbortException {
+    public static String createKlocworkAPIRequestOld(String action,
+                                                     String query, EnvVars envVars) throws AbortException {
 
         String request = "action=" + action + "&project=" + envVars.get(KlocworkConstants.KLOCWORK_PROJECT);
         if (!StringUtils.isEmpty(query)) {
@@ -409,6 +410,27 @@ public class KlocworkUtil {
 
         return request;
     }
+
+    public static String createKlocworkAPIRequest(String action, HashMap<String, String> args) throws AbortException {
+        String request = "&action="+action;
+        if (!args.isEmpty()) {
+            try {
+                for(String key : args.keySet()){
+                    if(action.equals("search") && key.equals("query")){
+                        request += "&"+key+"="+URLEncoder.encode(KlocworkUtil.getQueryDefaultGroupingOff(args.get(key))+args.get(key), "UTF-8");
+                    }
+                    else {
+                        request += "&" + key + "=" + URLEncoder.encode(args.get(key), "UTF-8");
+                    }
+                }
+            } catch (UnsupportedEncodingException ex) {
+                throw new AbortException(ex.getMessage());
+            }
+        }
+        return request;
+    }
+
+
 
     public static JSONArray getJSONRespose(String request,
         EnvVars envVars, Launcher launcher) throws AbortException {


### PR DESCRIPTION
Where projects have invalid url char's such as spaces or have been renamed the server links did not work. Added code to automatically pickup the correct project ID for url links.